### PR TITLE
修复以引用外部代码的语法引用本地代码导致编译失败的问题

### DIFF
--- a/packages/badanmu/src/create-client.ts
+++ b/packages/badanmu/src/create-client.ts
@@ -1,7 +1,7 @@
-import Bilibili from 'bilibili'
-import Douyu from 'douyu'
-import Huya from 'huya'
-import Kuaishou from 'kuaishou'
+import Bilibili from './bilibili'
+import Douyu from './douyu'
+import Huya from './huya'
+import Kuaishou from './kuaishou'
 
 export type Client = Bilibili | Douyu | Huya | Kuaishou
 

--- a/packages/badanmu/src/server.ts
+++ b/packages/badanmu/src/server.ts
@@ -7,7 +7,7 @@ import Douyu from './douyu'
 import Huya from './huya'
 import Kuaishou from './kuaishou'
 import log from './log'
-import { createClient } from 'create-client'
+import { createClient } from './create-client'
 
 type ClientMessage = {
   type?: string


### PR DESCRIPTION
没用过 monorepo 不确定是不是我的问题，姑且先发 PR 了，不对的话就 close 掉吧。

我是在项目根目录下 `yarn` 了一次，之后又分别在 `packages/` 下的两个子目录里 `yarn` 了一下，各自下载了依赖项目。
之后我在 `packages/badanmu/` 下执行 `yarn start 8181`, 报错说找不到我修改的那几个 module。我按照 PR 中的方式修改之后再重新执行就运行成功了。